### PR TITLE
Remove react-router-dom

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,29 +1,18 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import HomePage from './pages/HomePage';
-import WorkPage from './pages/WorkPage';
-import AboutPage from './pages/AboutPage';
-import ProjectDetailPage from './pages/ProjectDetailPage';
-import StartPage from './pages/StartPage';
-import SuccessPage from './pages/SuccessPage';
-import CancelPage from './pages/CancelPage';
+"use client";
+
+import { ReactNode } from 'react';
 import Layout from './components/Layout';
 import { ProjectProvider } from './context/ProjectProvider';
 import './App.css';
 
-function App() {
+interface AppProps {
+  children: ReactNode;
+}
+
+function App({ children }: AppProps) {
   return (
     <ProjectProvider>
-      <Router>
-        <Routes>
-          <Route path="/start" element={<StartPage />} />
-          <Route path="/success" element={<Layout><SuccessPage /></Layout>} />
-          <Route path="/cancel" element={<Layout><CancelPage /></Layout>} />
-          <Route path="/" element={<Layout><HomePage /></Layout>} />
-          <Route path="/work" element={<Layout><WorkPage /></Layout>} />
-          <Route path="/about" element={<Layout><AboutPage /></Layout>} />
-          <Route path="/project/:id" element={<Layout><ProjectDetailPage /></Layout>} />
-        </Routes>
-      </Router>
+      <Layout>{children}</Layout>
     </ProjectProvider>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,7 @@
+'use client';
+
 import { Mail, ArrowRight, Instagram } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import Link from 'next/link';
 
 const Footer = () => {
   return (
@@ -49,7 +51,7 @@ const Footer = () => {
             </div>
             
             <Link
-              to="/start"
+              href="/start"
               className="group inline-flex items-center gap-2 text-gray-300 hover:text-white text-sm transition-colors whitespace-nowrap"
             >
               Ready to start?

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,14 @@
+'use client';
+
 import { useState, useEffect } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { Menu, X } from 'lucide-react';
 
 const Header = () => {
   const [isScrolled, setIsScrolled] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const location = useLocation();
+  const pathname = usePathname();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -25,7 +28,7 @@ const Header = () => {
   };
 
   const isActive = (path: string) => {
-    return location.pathname === path;
+    return pathname === path;
   };
 
   return (
@@ -35,7 +38,7 @@ const Header = () => {
       }`}
     >
       <div className="container mx-auto px-4 md:px-8 flex justify-between items-center">
-        <Link to="/" className="h-12 md:h-16">
+        <Link href="/" className="h-12 md:h-16">
           <img 
             src="/images/logos/pattern3black.png" 
             alt="Pattern3 Logo" 
@@ -46,7 +49,7 @@ const Header = () => {
         {/* Desktop Menu - Right Aligned */}
         <nav className="hidden md:flex gap-10 ml-auto">
           <Link
-            to="/"
+            href="/"
             className={`transition-all duration-300 font-medium text-lg hover:text-primary ${
               isActive('/') ? 'text-primary font-semibold' : 'text-gray-800'
             }`}
@@ -54,7 +57,7 @@ const Header = () => {
             Home
           </Link>
           <Link
-            to="/work"
+            href="/work"
             className={`transition-all duration-300 font-medium text-lg hover:text-primary ${
               isActive('/work') ? 'text-primary font-semibold' : 'text-gray-800'
             }`}
@@ -62,7 +65,7 @@ const Header = () => {
             Work
           </Link>
           <Link
-            to="/start"
+            href="/start"
             className={`transition-all duration-300 font-medium text-lg hover:text-primary ${
               isActive('/start') ? 'text-primary font-semibold' : 'text-gray-800'
             }`}
@@ -70,7 +73,7 @@ const Header = () => {
             Start
           </Link>
           <Link
-            to="/about"
+            href="/about"
             className={`transition-all duration-300 font-medium text-lg hover:text-primary ${
               isActive('/about') ? 'text-primary font-semibold' : 'text-gray-800'
             }`}
@@ -94,7 +97,7 @@ const Header = () => {
         <div className="md:hidden bg-white/95 backdrop-blur-md absolute top-full left-0 w-full shadow-lg border-t border-gray-200">
           <div className="container mx-auto px-4 py-6 flex flex-col gap-6">
             <Link
-              to="/"
+              href="/"
               className={`py-3 px-4 text-lg font-medium transition-colors ${
                 isActive('/') ? 'text-primary font-semibold' : 'text-gray-800'
               }`}
@@ -103,7 +106,7 @@ const Header = () => {
               Home
             </Link>
             <Link
-              to="/work"
+              href="/work"
               className={`py-3 px-4 text-lg font-medium transition-colors ${
                 isActive('/work') ? 'text-primary font-semibold' : 'text-gray-800'
               }`}
@@ -112,7 +115,7 @@ const Header = () => {
               Work
             </Link>
             <Link
-              to="/start"
+              href="/start"
               className={`py-3 px-4 text-lg font-medium transition-colors ${
                 isActive('/start') ? 'text-primary font-semibold' : 'text-gray-800'
               }`}
@@ -121,7 +124,7 @@ const Header = () => {
               Start
             </Link>
             <Link
-              to="/about"
+              href="/about"
               className={`py-3 px-4 text-lg font-medium transition-colors ${
                 isActive('/about') ? 'text-primary font-semibold' : 'text-gray-800'
               }`}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,7 @@
+'use client';
+
 import { ReactNode, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { usePathname } from 'next/navigation';
 import Header from './Header';
 import Footer from './Footer';
 
@@ -8,11 +10,11 @@ interface LayoutProps {
 }
 
 const Layout = ({ children }: LayoutProps) => {
-  const location = useLocation();
+  const pathname = usePathname();
 
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, [location.pathname]);
+  }, [pathname]);
 
   return (
     <div className="flex flex-col min-h-screen">

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import Link from 'next/link';
 import { Home } from 'lucide-react';
 
 const NotFound = () => {
@@ -13,7 +13,7 @@ const NotFound = () => {
           or is temporarily unavailable.
         </p>
         <Link
-          to="/"
+          href="/"
           className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-md transition hover:bg-primary-dark"
         >
           <Home size={18} /> Go to Homepage

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,5 +1,7 @@
+'use client';
+
 import { ArrowRight } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import Link from 'next/link';
 import { Project } from '../types/Project';
 
 interface ProjectCardProps {
@@ -9,7 +11,7 @@ interface ProjectCardProps {
 const ProjectCard = ({ project }: ProjectCardProps) => {
   return (
     <Link
-      to={`/project/${project.id}`}
+      href={`/project/${project.id}`}
       className="block group"
     >
       <div className="card relative overflow-hidden transition-all duration-500 transform md:group-hover:-translate-y-2 md:group-hover:shadow-2xl border-0">

--- a/src/pages/AIPage.tsx
+++ b/src/pages/AIPage.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import { useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import Link from 'next/link';
 import { FileText, Mail, ArrowRight } from 'lucide-react';
 import { useProjectContext } from '../hooks/useProjectContext';
 
@@ -106,7 +108,7 @@ const AIPage = () => {
                   <h3 className="text-xl font-semibold mb-2">{project?.title}</h3>
                   <p className="text-gray-600 mb-4">{project?.description}</p>
                   <Link
-                    to={`/project/${project?.id}`}
+                    href={`/project/${project?.id}`}
                     className="inline-flex items-center text-primary hover:text-primary-dark"
                   >
                     View Project <ArrowRight size={16} className="ml-1" />

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 import { useEffect } from 'react';
 import { FileText, Mail, ArrowRight, Zap, Target, Users, Search, Lightbulb, Rocket } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import Link from 'next/link';
 
 const AboutPage = () => {
   useEffect(() => {
@@ -270,7 +272,7 @@ const AboutPage = () => {
                 </p>
                 <div className="flex flex-wrap justify-center gap-6">
                   <Link
-                    to="/start"
+                    href="/start"
                     className="btn-primary inline-flex items-center gap-3 text-lg"
                   >
                     Get Started <ArrowRight size={20} />

--- a/src/pages/CancelPage.tsx
+++ b/src/pages/CancelPage.tsx
@@ -1,5 +1,7 @@
+'use client';
+
 import { useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import Link from 'next/link';
 import { XCircle } from 'lucide-react';
 
 export default function CancelPage() {
@@ -19,7 +21,7 @@ export default function CancelPage() {
             Your purchase was cancelled. If you have any questions, please don't hesitate to contact us.
           </p>
           <Link
-            to="/"
+            href="/"
             className="inline-block px-6 py-3 bg-primary text-white rounded-md hover:bg-primary-dark transition-colors"
           >
             Return to Home

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 import { useRef, useState, useEffect } from 'react';
 import { ArrowRight, Check, Users, Building, Stethoscope, UserCheck, FileText, MessageCircle, Video, Plus, Shield, Zap, Target, Sparkles } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import Link from 'next/link';
 import ProjectCard from '../components/ProjectCard';
 import { useProjectContext } from '../hooks/useProjectContext';
 import RoadmapBookingModal from '../components/RoadmapBookingModal';
@@ -86,7 +88,7 @@ const HomePage = () => {
                   Book Free Consultation <ArrowRight size={20} />
                 </button>
                 <Link
-                  to="/work"
+                  href="/work"
                   className="btn-outline inline-flex items-center justify-center gap-3 text-base md:text-lg max-w-full"
                   aria-label="View Case Studies"
                 >
@@ -352,7 +354,7 @@ const HomePage = () => {
           
           <div className="text-center mt-16 max-w-full">
             <Link
-              to="/work"
+              href="/work"
               className="btn-primary inline-flex items-center gap-3 text-base md:text-lg"
               aria-label="View All Case Studies"
             >

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
 import { ArrowLeft, ArrowRight } from 'lucide-react';
 import { useProjectContext } from '../hooks/useProjectContext';
 import ProjectGallery from '../components/ProjectGallery';
@@ -41,8 +44,8 @@ const ProjectDetailPage = () => {
   return (
     <div className="min-h-screen pt-24 pb-20 bg-white">
       <div className="container mx-auto px-4 md:px-8">
-        <Link 
-          to="/work" 
+        <Link
+          href="/work"
           className="inline-flex items-center gap-2 text-gray-600 hover:text-primary mb-8"
         >
           <ArrowLeft size={16} /> Back to all projects
@@ -119,8 +122,8 @@ const ProjectDetailPage = () => {
           <div className="border-t border-gray-200 pt-8 mt-12">
             <div className="flex justify-between">
               {prevProject ? (
-                <Link 
-                  to={`/project/${prevProject}`}
+                <Link
+                  href={`/project/${prevProject}`}
                   className="inline-flex items-center gap-2 text-gray-700 hover:text-primary"
                 >
                   <ArrowLeft size={16} /> Previous Project
@@ -130,8 +133,8 @@ const ProjectDetailPage = () => {
               )}
               
               {nextProject ? (
-                <Link 
-                  to={`/project/${nextProject}`}
+                <Link
+                  href={`/project/${nextProject}`}
                   className="inline-flex items-center gap-2 text-gray-700 hover:text-primary"
                 >
                   Next Project <ArrowRight size={16} />

--- a/src/pages/StartPage.tsx
+++ b/src/pages/StartPage.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+"use client";
+
+import Link from 'next/link';
 import { ChevronLeft, Mail, MessageCircle, ArrowRight, Instagram } from 'lucide-react';
 import BookingForm from '../components/BookingForm';
 
@@ -80,7 +82,7 @@ const StartPage = () => {
       >
         <div className="container mx-auto px-4 py-4 flex justify-between items-center">
           <Link
-            to="/"
+            href="/"
             className="inline-flex items-center text-gray-600 hover:text-primary transition-colors font-medium"
           >
             <ChevronLeft className="w-5 h-5" />

--- a/src/pages/SuccessPage.tsx
+++ b/src/pages/SuccessPage.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import { useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import Link from 'next/link';
 import { CheckCircle } from 'lucide-react';
 
 export default function SuccessPage() {
@@ -19,7 +21,7 @@ export default function SuccessPage() {
             Your purchase was successful. You'll receive an email with further instructions shortly.
           </p>
           <Link
-            to="/"
+            href="/"
             className="inline-block px-6 py-3 bg-primary text-white rounded-md hover:bg-primary-dark transition-colors"
           >
             Return to Home

--- a/src/pages/WorkPage.tsx
+++ b/src/pages/WorkPage.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 import { useState, useEffect } from 'react';
 import { ArrowRight } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import Link from 'next/link';
 import { useProjectContext } from '../hooks/useProjectContext';
 import ProjectCard from '../components/ProjectCard';
 
@@ -149,7 +151,7 @@ const WorkPage = () => {
                 Ready to transform your business with custom AI solutions? Let's discuss your project.
               </p>
               <Link
-                to="/start"
+                href="/start"
                 className="btn-primary inline-flex items-center gap-3 text-lg"
               >
                 Start Your Project <ArrowRight size={20} />


### PR DESCRIPTION
## Summary
- drop `react-router-dom`
- use Next.js routing utilities across components and pages

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: numerous module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866ea58b7108330ab5823fd0ca80efb