### PR TITLE
chore: add deploy config for Vercel + Netlify routing support

### DIFF
--- a/.vercel/project.json
+++ b/.vercel/project.json
@@ -1,0 +1,5 @@
+{
+  "framework": "nextjs",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next"
+}

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,2 @@
+/ai  https://pattern3.com/  301!
+/*   /index.html           200

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  command = "npm run build"
+  publish = ".next"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,3 @@
+import HomePage from './HomePage';
+
+export default HomePage;


### PR DESCRIPTION
## Summary
- add Netlify build settings and SPA redirect
- provide root redirect rules for Netlify
- add missing index page
- configure Vercel project settings

## Testing
- `npm install` *(passed)*
- `npm run build` *(failed: Failed to fetch `Inter` font)*
- `npm run lint` *(failed: interactive prompt)*
- `npm run type-check` *(failed: multiple TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866fb33829c83309029d9b2280d45d1