### PR TITLE
fix: patch font loading and Netlify build config for successful deploy

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
 
 @font-face {
   font-family: 'Pattern';

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,12 @@ import { Inter } from 'next/font/google'
 import './globals.css'
 import { ProjectProvider } from '@/context/ProjectProvider'
 
-const inter = Inter({ subsets: ['latin'] })
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+  preload: false,
+  fallback: ['system-ui', 'Arial', 'sans-serif']
+})
 
 export const metadata: Metadata = {
   title: {

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,10 @@
   command = "npm run build"
   publish = ".next"
 
+[dev]
+  command = "npm run dev"
+  port = 3000
+
 [[redirects]]
   from = "/*"
   to = "/index.html"


### PR DESCRIPTION
## Summary
- stop fetching Inter from Google Fonts
- tune Inter import to use local fallbacks and no preloading
- add Netlify dev section

## Testing
- `npm run build` *(fails: Conflicting app and page file was found)*

------
https://chatgpt.com/codex/tasks/task_e_6866fd3f88608330b3cc450acb2f26e5